### PR TITLE
feat: ボタンのデザイン修正

### DIFF
--- a/components/ImageEditor.tsx
+++ b/components/ImageEditor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { X, RotateCcw, Download } from 'lucide-react'
 
 interface Line {
   start: { x: number; y: number }
@@ -578,23 +579,26 @@ export default function ImageEditor() {
       
       <button
         onClick={closeImage}
-        className="absolute top-4 right-4 w-10 h-10 bg-red-500 text-white rounded-full flex items-center justify-center hover:bg-red-600 z-10"
+        className="absolute top-4 right-4 w-12 h-12 bg-gray-700 text-gray-300 rounded-full flex items-center justify-center hover:bg-gray-600 transition-colors z-10"
+        aria-label="閉じる"
       >
-        ×
+        <X size={24} />
       </button>
       
       <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex gap-4 z-10">
         <button
           onClick={undo}
-          className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+          className="w-12 h-12 bg-gray-700 text-gray-300 rounded-full flex items-center justify-center hover:bg-gray-600 transition-colors"
+          aria-label="元に戻す"
         >
-          元に戻す
+          <RotateCcw size={24} />
         </button>
         <button
           onClick={download}
-          className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+          className="w-12 h-12 bg-gray-700 text-gray-300 rounded-full flex items-center justify-center hover:bg-gray-600 transition-colors"
+          aria-label="ダウンロード"
         >
-          ダウンロード
+          <Download size={24} />
         </button>
       </div>
       

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mesen-app",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.514.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18"
@@ -3782,6 +3783,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.514.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.514.0.tgz",
+      "integrity": "sha512-HXD0OAMd+JM2xCjlwG1EGW9Nuab64dhjO3+MvdyD+pSUeOTBaVAPhQblKIYmmX4RyBYbdzW0VWnJpjJmxWGr6w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "login": "vercel login"
   },
   "dependencies": {
+    "lucide-react": "^0.514.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
## Summary

ボタンのデザインを修正しました。

- 閉じるボタン、元に戻すボタン、ダウンロードボタンを円形アイコンに変更
- lucide-reactを使用してアイコンを実装
- グレースケールの色に統一
- テキストラベルを削除しアイコンのみの表示に変更

Fixes #6

Generated with [Claude Code](https://claude.ai/code)